### PR TITLE
Test: Change the way to store transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,5 +47,5 @@ Teste atualizado com mais garantias de concorrencia.
 ### Menções
 
 - [Artur Sampaio](https://github.com/arturvrsampaio) -> Dicas de otimizações do banco.
-- [Rodolfo](https://github.com/RodolphoVSantoro) -> Dicas de otimizações do código.
+- [Rodolpho](https://github.com/RodolphoVSantoro) -> Dicas de otimizações do código.
 - [Rafael Telles](https://github.com/rafael-telles) -> Dicas de otimizações gerais e como achar pontos de melhora.

--- a/db/20240206002504_init_rinha.sql
+++ b/db/20240206002504_init_rinha.sql
@@ -1,14 +1,20 @@
--- Add migration script here
+-- drop index transactions_client_id_index;
+-- drop index transactions_created_at_index;
+-- drop table transactions ;
+-- drop table clients;
 
-CREATE TABLE clients (
+create table clients (
   id SERIAL PRIMARY KEY,
   balance_limit INT DEFAULT 0 NOT NULL,
   balance INT DEFAULT 0 NOT NULL,
+  last_nt INT DEFAULT 0 NOT NULL,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
 );
 
-CREATE TABLE transactions (
+create TABLE IF NOT EXISTS transactions (
   id SERIAL PRIMARY KEY,
+  nt INT NOT NULL,
+  valid BOOLEAN DEFAULT FALSE NOT NULL,
   client_id SERIAL REFERENCES clients(id) NOT NULL,
   amount INT NOT NULL,
   description VARCHAR(10) NOT NULL,
@@ -16,11 +22,69 @@ CREATE TABLE transactions (
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
 );
 
-CREATE INDEX transactions_client_id_index ON transactions(client_id);
-CREATE INDEX transactions_created_at_index ON transactions(created_at DESC);
+delete from transactions;
+delete from clients;
 
-INSERT INTO clients (balance_limit, balance) VALUES (100000, 0);
-INSERT INTO clients (balance_limit, balance) VALUES (80000, 0);
-INSERT INTO clients (balance_limit, balance) VALUES (1000000, 0);
-INSERT INTO clients (balance_limit, balance) VALUES (10000000, 0);
-INSERT INTO clients (balance_limit, balance) VALUES (500000, 0);
+CREATE index if not exists transactions_client_id_index ON transactions(client_id);
+create INDEX if not exists transactions_created_at_index ON transactions(created_at DESC);
+
+INSERT INTO clients (balance_limit) VALUES (100000);
+INSERT INTO clients (balance_limit) VALUES (80000);
+INSERT INTO clients (balance_limit) VALUES (1000000);
+INSERT INTO clients (balance_limit) VALUES (10000000);
+INSERT INTO clients (balance_limit) VALUES (500000);
+
+insert into transactions (client_id, nt, amount, description, type) values (1, 0, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (1, 1, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (1, 2, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (1, 3, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (1, 4, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (1, 5, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (1, 6, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (1, 7, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (1, 8, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (1, 9, 0, '', '');
+
+insert into transactions (client_id, nt, amount, description, type) values (2, 0, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (2, 1, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (2, 2, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (2, 3, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (2, 4, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (2, 5, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (2, 6, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (2, 7, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (2, 8, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (2, 9, 0, '', '');
+
+insert into transactions (client_id, nt, amount, description, type) values (3, 0, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (3, 1, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (3, 2, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (3, 3, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (3, 4, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (3, 5, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (3, 6, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (3, 7, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (3, 8, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (3, 9, 0, '', '');
+
+insert into transactions (client_id, nt, amount, description, type) values (4, 0, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (4, 1, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (4, 2, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (4, 3, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (4, 4, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (4, 5, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (4, 6, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (4, 7, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (4, 8, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (4, 9, 0, '', '');
+
+insert into transactions (client_id, nt, amount, description, type) values (5, 0, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (5, 1, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (5, 2, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (5, 3, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (5, 4, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (5, 5, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (5, 6, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (5, 7, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (5, 8, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (5, 9, 0, '', '');

--- a/executarTesteScala.sh
+++ b/executarTesteScala.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/bash
+
+# Use este script para executar testes locais
+
+RESULTS_WORKSPACE="$(pwd)/load-test/user-files/results"
+GATLING_BIN_DIR=$HOME/Documents/rinha-backend/gatling/bin
+GATLING_WORKSPACE="$(pwd)/load-test/user-files"
+
+runGatling() {
+    sh $GATLING_BIN_DIR/gatling.sh -rm local -s RinhaBackendCrebitosSimulation \
+        -rd "Rinha de Backend - 2024/Q1: Crébito" \
+        -rf $RESULTS_WORKSPACE \
+        -sf "$GATLING_WORKSPACE/simulations"
+}
+
+startTest() {
+    for i in {1..20}; do
+        # 2 requests to wake the 2 api instances up :)
+        curl --fail http://localhost:9999/clientes/1/extrato && \
+        echo "" && \
+        curl --fail http://localhost:9999/clientes/1/extrato && \
+        echo "" && \
+        runGatling && \
+        break || sleep 2;
+    done
+}
+
+startTest

--- a/load-test/user-files/.gitignore
+++ b/load-test/user-files/.gitignore
@@ -1,0 +1,1 @@
+results

--- a/load-test/user-files/simulations/rinhabackend/RinhaBackendCrebitosSimulation.scala
+++ b/load-test/user-files/simulations/rinhabackend/RinhaBackendCrebitosSimulation.scala
@@ -1,0 +1,281 @@
+// from https://github.com/zanfranceschi/rinha-de-backend-2024-q1/blob/main/load-test/user-files/simulations/rinhabackend/RinhaBackendCrebitosSimulation.scala
+
+import scala.concurrent.duration._
+
+import scala.util.Random
+
+import util.Try
+
+import io.gatling.commons.validation._
+import io.gatling.core.session.Session
+import io.gatling.core.Predef._
+import io.gatling.http.Predef._
+
+
+class RinhaBackendCrebitosSimulation
+  extends Simulation {
+
+  def randomClienteId() = Random.between(1, 5 + 1)
+  def randomValorTransacao() = Random.between(1, 10000 + 1)
+  def randomDescricao() = Random.alphanumeric.take(10).mkString
+  def randomTipoTransacao() = Seq("c", "d", "d")(Random.between(0, 2 + 1)) // not used
+  def toInt(s: String): Option[Int] = {
+    try {
+      Some(s.toInt)
+    } catch {
+      case e: Exception => None
+    }
+  }
+
+  val validarConsistenciaSaldoLimite = (valor: Option[String], session: Session) => {
+    /*
+      Essa função é frágil porque depende que haja uma entrada
+      chamada 'limite' com valor conversível para int na session
+      e também que seja encadeada com com jmesPath("saldo") para
+      que 'valor' seja o primeiro argumento da função validadora
+      de 'validate(.., ..)'.
+      
+      =============================================================
+      
+      Nota para quem não tem experiência em testes de performance:
+        O teste de lógica de saldo/limite extrapola o que é comumente 
+        feito em testes de performance apenas por causa da natureza
+        da Rinha de Backend. Evite fazer esse tipo de coisa em 
+        testes de performance, pois não é uma prática recomendada
+        normalmente.
+    */ 
+
+    val saldo = valor.flatMap(s => Try(s.toInt).toOption)
+    val limite = toInt(session("limite").as[String])
+
+    (saldo, limite) match {
+      case (Some(s), Some(l)) if s.toInt < l.toInt * -1 => Failure("Limite ultrapassado!")
+      case (Some(s), Some(l)) if s.toInt >= l.toInt * -1 => Success(Option("ok"))
+      case _ => Failure("WTF?!")
+    }
+  }
+
+  val httpProtocol = http
+    .baseUrl("http://localhost:9999")
+    .userAgentHeader("Agente do Caos - 2024/Q1")
+
+  val debitos = scenario("débitos")
+    .exec {s =>
+      val descricao = randomDescricao()
+      val cliente_id = randomClienteId()
+      val valor = randomValorTransacao()
+      val payload = s"""{"valor": ${valor}, "tipo": "d", "descricao": "${descricao}"}"""
+      val session = s.setAll(Map("descricao" -> descricao, "cliente_id" -> cliente_id, "payload" -> payload))
+      session
+    }
+    .exec(
+      http("débitos")
+      .post(s => s"/clientes/${s("cliente_id").as[String]}/transacoes")
+          .header("content-type", "application/json")
+          .body(StringBody(s => s("payload").as[String]))
+          .check(
+            status.in(200, 422),
+            status.saveAs("httpStatus"))
+          .checkIf(s => s("httpStatus").as[String] == "200") { jmesPath("limite").saveAs("limite") }
+          .checkIf(s => s("httpStatus").as[String] == "200") {
+            jmesPath("saldo").validate("ConsistenciaSaldoLimite - Transação", validarConsistenciaSaldoLimite)
+          }
+    )
+
+  val creditos = scenario("créditos")
+    .exec {s =>
+      val descricao = randomDescricao()
+      val cliente_id = randomClienteId()
+      val valor = randomValorTransacao()
+      val payload = s"""{"valor": ${valor}, "tipo": "c", "descricao": "${descricao}"}"""
+      val session = s.setAll(Map("descricao" -> descricao, "cliente_id" -> cliente_id, "payload" -> payload))
+      session
+    }
+    .exec(
+      http("créditos")
+      .post(s => s"/clientes/${s("cliente_id").as[String]}/transacoes")
+          .header("content-type", "application/json")
+          .body(StringBody(s => s("payload").as[String]))
+          .check(
+            status.in(200),
+            jmesPath("limite").saveAs("limite"),
+            jmesPath("saldo").validate("ConsistenciaSaldoLimite - Transação", validarConsistenciaSaldoLimite)
+          )
+    )
+
+  val extratos = scenario("extratos")
+    .exec(
+      http("extratos")
+      .get(s => s"/clientes/${randomClienteId()}/extrato")
+      .check(
+        jmesPath("saldo.limite").saveAs("limite"),
+        jmesPath("saldo.total").validate("ConsistenciaSaldoLimite - Extrato", validarConsistenciaSaldoLimite)
+    )
+  )
+
+  val validacaConcorrentesNumRequests = 25
+  val validacaoTransacoesConcorrentes = (tipo: String) =>
+    scenario(s"validação concorrência transações - ${tipo}")
+    .exec(
+      http("validações")
+      .post(s"/clientes/1/transacoes")
+          .header("content-type", "application/json")
+          .body(StringBody(s"""{"valor": 1, "tipo": "${tipo}", "descricao": "validacao"}"""))
+          .check(status.is(200))
+    )
+  
+  val validacaoTransacoesConcorrentesSaldo = (saldoEsperado: Int) =>
+    scenario(s"validação concorrência saldo - ${saldoEsperado}")
+    .exec(
+      http("validações")
+      .get(s"/clientes/1/extrato")
+      .check(
+        jmesPath("saldo.total").ofType[Int].is(saldoEsperado)
+      )
+    )
+
+  val saldosIniciaisClientes = Array(
+    Map("id" -> 1, "limite" ->   1000 * 100),
+    Map("id" -> 2, "limite" ->    800 * 100),
+    Map("id" -> 3, "limite" ->  10000 * 100),
+    Map("id" -> 4, "limite" -> 100000 * 100),
+    Map("id" -> 5, "limite" ->   5000 * 100),
+  )
+
+  val criterioClienteNaoEcontrado = scenario("validação HTTP 404")
+    .exec(
+      http("validações")
+      .get("/clientes/6/extrato")
+      .check(status.is(404))
+    )
+
+  val criteriosClientes = scenario("validações")
+    .feed(saldosIniciaisClientes)
+    .exec(
+      /*
+        Os valores de http(...) essão duplicados propositalmente
+        para que sejam agrupados no relatório e ocupem menos espaço.
+        O lado negativo é que, em caso de falha, pode não ser possível
+        saber sua causa exata.
+      */ 
+      http("validações")
+      .get("/clientes/#{id}/extrato")
+      .check(
+        status.is(200),
+        jmesPath("saldo.limite").ofType[String].is("#{limite}"),
+        jmesPath("saldo.total").ofType[String].is("0")
+      )
+    )
+    .exec(
+      http("validações")
+      .post("/clientes/#{id}/transacoes")
+          .header("content-type", "application/json")
+          .body(StringBody(s"""{"valor": 1, "tipo": "c", "descricao": "toma"}"""))
+          .check(
+            status.in(200),
+            jmesPath("limite").saveAs("limite"),
+            jmesPath("saldo").validate("ConsistenciaSaldoLimite - Transação", validarConsistenciaSaldoLimite)
+          )
+    )
+    .exec(
+      http("validações")
+      .post("/clientes/#{id}/transacoes")
+          .header("content-type", "application/json")
+          .body(StringBody(s"""{"valor": 1, "tipo": "d", "descricao": "devolve"}"""))
+          .check(
+            status.in(200),
+            jmesPath("limite").saveAs("limite"),
+            jmesPath("saldo").validate("ConsistenciaSaldoLimite - Transação", validarConsistenciaSaldoLimite)
+          )
+    )
+    .exec(
+      http("validações")
+      .get("/clientes/#{id}/extrato")
+      .check(
+        jmesPath("ultimas_transacoes[0].descricao").ofType[String].is("devolve"),
+        jmesPath("ultimas_transacoes[0].tipo").ofType[String].is("d"),
+        jmesPath("ultimas_transacoes[0].valor").ofType[Int].is("1"),
+        jmesPath("ultimas_transacoes[1].descricao").ofType[String].is("toma"),
+        jmesPath("ultimas_transacoes[1].tipo").ofType[String].is("c"),
+        jmesPath("ultimas_transacoes[1].valor").ofType[Int].is("1")
+    )
+  )
+  .exec(
+      http("validações")
+      .post("/clientes/#{id}/transacoes")
+          .header("content-type", "application/json")
+          .body(StringBody(s"""{"valor": 1.2, "tipo": "d", "descricao": "devolve"}"""))
+          .check(status.in(422))
+    )
+    .exec(
+      http("validações")
+      .post("/clientes/#{id}/transacoes")
+          .header("content-type", "application/json")
+          .body(StringBody(s"""{"valor": 1, "tipo": "x", "descricao": "devolve"}"""))
+          .check(status.in(422))
+    )
+    .exec(
+      http("validações")
+      .post("/clientes/#{id}/transacoes")
+          .header("content-type", "application/json")
+          .body(StringBody(s"""{"valor": 1, "tipo": "c", "descricao": "123456789 e mais um pouco"}"""))
+          .check(status.in(422))
+    )
+    .exec(
+      http("validações")
+      .post("/clientes/#{id}/transacoes")
+          .header("content-type", "application/json")
+          .body(StringBody(s"""{"valor": 1, "tipo": "c", "descricao": ""}"""))
+          .check(status.in(422))
+    )
+    .exec(
+      http("validações")
+      .post("/clientes/#{id}/transacoes")
+          .header("content-type", "application/json")
+          .body(StringBody(s"""{"valor": 1, "tipo": "c", "descricao": null}"""))
+          .check(status.in(422))
+    )
+
+  /* 
+    Separar créditos e débitos dá uma visão
+    melhor sobre como as duas operações se
+    comportam individualmente.
+  */
+  setUp(
+    validacaoTransacoesConcorrentes("d").inject(
+      atOnceUsers(validacaConcorrentesNumRequests)
+    ).andThen(
+      validacaoTransacoesConcorrentesSaldo(validacaConcorrentesNumRequests * -1).inject(
+        atOnceUsers(1)
+      )
+    ).andThen(
+      validacaoTransacoesConcorrentes("c").inject(
+        atOnceUsers(validacaConcorrentesNumRequests)
+      ).andThen(
+        validacaoTransacoesConcorrentesSaldo(0).inject(
+          atOnceUsers(1)
+        )
+      )
+    ).andThen(
+      criteriosClientes.inject(
+        atOnceUsers(saldosIniciaisClientes.length)
+      ),
+      criterioClienteNaoEcontrado.inject(
+        atOnceUsers(1)
+      ).andThen(
+        debitos.inject(
+          rampUsersPerSec(1).to(520).during(2.minutes),
+          constantUsersPerSec(520).during(2.minutes)
+        ),
+        creditos.inject(
+          rampUsersPerSec(1).to(410).during(2.minutes),
+          constantUsersPerSec(410).during(2.minutes)
+        ),
+        extratos.inject(
+          rampUsersPerSec(1).to(40).during(2.minutes),
+          constantUsersPerSec(40).during(2.minutes)
+        )
+      )
+    )
+  ).protocols(httpProtocol)
+}

--- a/migrations/20240206002504_init_rinha.sql
+++ b/migrations/20240206002504_init_rinha.sql
@@ -1,14 +1,20 @@
--- Add migration script here
+-- drop index transactions_client_id_index;
+-- drop index transactions_created_at_index;
+-- drop table transactions ;
+-- drop table clients;
 
-CREATE TABLE clients (
+create table clients (
   id SERIAL PRIMARY KEY,
   balance_limit INT DEFAULT 0 NOT NULL,
   balance INT DEFAULT 0 NOT NULL,
+  last_nt INT DEFAULT 0 NOT NULL,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
 );
 
-CREATE TABLE transactions (
+create TABLE IF NOT EXISTS transactions (
   id SERIAL PRIMARY KEY,
+  nt INT NOT NULL,
+  valid BOOLEAN DEFAULT FALSE NOT NULL,
   client_id SERIAL REFERENCES clients(id) NOT NULL,
   amount INT NOT NULL,
   description VARCHAR(10) NOT NULL,
@@ -16,11 +22,69 @@ CREATE TABLE transactions (
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
 );
 
-CREATE INDEX transactions_client_id_index ON transactions(client_id);
-CREATE INDEX transactions_created_at_index ON transactions(created_at DESC);
+delete from transactions;
+delete from clients;
 
-INSERT INTO clients (balance_limit, balance) VALUES (100000, 0);
-INSERT INTO clients (balance_limit, balance) VALUES (80000, 0);
-INSERT INTO clients (balance_limit, balance) VALUES (1000000, 0);
-INSERT INTO clients (balance_limit, balance) VALUES (10000000, 0);
-INSERT INTO clients (balance_limit, balance) VALUES (500000, 0);
+CREATE index if not exists transactions_client_id_index ON transactions(client_id);
+create INDEX if not exists transactions_created_at_index ON transactions(created_at DESC);
+
+INSERT INTO clients (balance_limit) VALUES (100000);
+INSERT INTO clients (balance_limit) VALUES (80000);
+INSERT INTO clients (balance_limit) VALUES (1000000);
+INSERT INTO clients (balance_limit) VALUES (10000000);
+INSERT INTO clients (balance_limit) VALUES (500000);
+
+insert into transactions (client_id, nt, amount, description, type) values (1, 0, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (1, 1, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (1, 2, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (1, 3, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (1, 4, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (1, 5, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (1, 6, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (1, 7, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (1, 8, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (1, 9, 0, '', '');
+
+insert into transactions (client_id, nt, amount, description, type) values (2, 0, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (2, 1, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (2, 2, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (2, 3, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (2, 4, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (2, 5, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (2, 6, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (2, 7, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (2, 8, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (2, 9, 0, '', '');
+
+insert into transactions (client_id, nt, amount, description, type) values (3, 0, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (3, 1, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (3, 2, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (3, 3, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (3, 4, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (3, 5, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (3, 6, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (3, 7, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (3, 8, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (3, 9, 0, '', '');
+
+insert into transactions (client_id, nt, amount, description, type) values (4, 0, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (4, 1, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (4, 2, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (4, 3, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (4, 4, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (4, 5, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (4, 6, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (4, 7, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (4, 8, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (4, 9, 0, '', '');
+
+insert into transactions (client_id, nt, amount, description, type) values (5, 0, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (5, 1, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (5, 2, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (5, 3, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (5, 4, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (5, 5, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (5, 6, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (5, 7, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (5, 8, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (5, 9, 0, '', '');

--- a/src/models/transaction.rs
+++ b/src/models/transaction.rs
@@ -23,5 +23,7 @@ pub struct TransactionModel {
     pub amount: i32,
     pub description: String,
     pub r#type: String,
+    pub nt: i32,
+    pub valid: bool,
     pub created_at: sqlx::types::chrono::NaiveDateTime,
 }

--- a/submission/001_init_rinha.sql
+++ b/submission/001_init_rinha.sql
@@ -1,14 +1,20 @@
--- Add migration script here
+-- drop index transactions_client_id_index;
+-- drop index transactions_created_at_index;
+-- drop table transactions ;
+-- drop table clients;
 
-CREATE TABLE clients (
+create table clients (
   id SERIAL PRIMARY KEY,
   balance_limit INT DEFAULT 0 NOT NULL,
   balance INT DEFAULT 0 NOT NULL,
+  last_nt INT DEFAULT 0 NOT NULL,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
 );
 
-CREATE TABLE transactions (
+create TABLE IF NOT EXISTS transactions (
   id SERIAL PRIMARY KEY,
+  nt INT NOT NULL,
+  valid BOOLEAN DEFAULT FALSE NOT NULL,
   client_id SERIAL REFERENCES clients(id) NOT NULL,
   amount INT NOT NULL,
   description VARCHAR(10) NOT NULL,
@@ -16,11 +22,69 @@ CREATE TABLE transactions (
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
 );
 
-CREATE INDEX transactions_client_id_index ON transactions(client_id);
-CREATE INDEX transactions_created_at_index ON transactions(created_at DESC);
+delete from transactions;
+delete from clients;
 
-INSERT INTO clients (balance_limit, balance) VALUES (100000, 0);
-INSERT INTO clients (balance_limit, balance) VALUES (80000, 0);
-INSERT INTO clients (balance_limit, balance) VALUES (1000000, 0);
-INSERT INTO clients (balance_limit, balance) VALUES (10000000, 0);
-INSERT INTO clients (balance_limit, balance) VALUES (500000, 0);
+CREATE index if not exists transactions_client_id_index ON transactions(client_id);
+create INDEX if not exists transactions_created_at_index ON transactions(created_at DESC);
+
+INSERT INTO clients (balance_limit) VALUES (100000);
+INSERT INTO clients (balance_limit) VALUES (80000);
+INSERT INTO clients (balance_limit) VALUES (1000000);
+INSERT INTO clients (balance_limit) VALUES (10000000);
+INSERT INTO clients (balance_limit) VALUES (500000);
+
+insert into transactions (client_id, nt, amount, description, type) values (1, 0, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (1, 1, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (1, 2, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (1, 3, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (1, 4, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (1, 5, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (1, 6, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (1, 7, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (1, 8, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (1, 9, 0, '', '');
+
+insert into transactions (client_id, nt, amount, description, type) values (2, 0, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (2, 1, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (2, 2, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (2, 3, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (2, 4, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (2, 5, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (2, 6, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (2, 7, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (2, 8, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (2, 9, 0, '', '');
+
+insert into transactions (client_id, nt, amount, description, type) values (3, 0, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (3, 1, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (3, 2, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (3, 3, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (3, 4, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (3, 5, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (3, 6, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (3, 7, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (3, 8, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (3, 9, 0, '', '');
+
+insert into transactions (client_id, nt, amount, description, type) values (4, 0, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (4, 1, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (4, 2, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (4, 3, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (4, 4, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (4, 5, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (4, 6, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (4, 7, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (4, 8, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (4, 9, 0, '', '');
+
+insert into transactions (client_id, nt, amount, description, type) values (5, 0, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (5, 1, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (5, 2, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (5, 3, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (5, 4, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (5, 5, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (5, 6, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (5, 7, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (5, 8, 0, '', '');
+insert into transactions (client_id, nt, amount, description, type) values (5, 9, 0, '', '');

--- a/submission/README.md
+++ b/submission/README.md
@@ -36,5 +36,5 @@
 ### Menções
 
 - [Artur Sampaio](https://github.com/arturvrsampaio) -> Dicas de otimizações do banco.
-- [Rodolfo](https://github.com/RodolphoVSantoro) -> Dicas de otimizações do código.
+- [Rodolpho](https://github.com/RodolphoVSantoro) -> Dicas de otimizações do código.
 - [Rafael Telles](https://github.com/rafael-telles) -> Dicas de otimizações gerais e como achar pontos de melhora.


### PR DESCRIPTION
Percebemos que uma das coisas que poderia ser melhorada era que o banco estava guardando muitas transacoes que nao eram utilizadas, pois somente as 10 ultimas eram requeridas nesta competicao.

Assim ao inves de criarmos mais transacoes nós apenas damos update nelas, deixando apenas 10 transacoes por usuario.